### PR TITLE
Adding an optional protocol method which determines whether non-tappable text should pass touches through

### DIFF
--- a/ZSWTappableLabel/ZSWTappableLabel.h
+++ b/ZSWTappableLabel/ZSWTappableLabel.h
@@ -58,6 +58,11 @@ extern NSString *const ZSWTappableLabelTappableRegionAttributeName;
 - (void)tappableLabel:(ZSWTappableLabel *)tappableLabel
         tappedAtIndex:(NSInteger)idx
        withAttributes:(NSDictionary *)attributes;
+
+@optional
+
+- (BOOL)tappableLabelShouldPassThroughUnhighlightedTouches:(ZSWTappableLabel *)tappableLabel;
+
 @end
 
 #pragma mark -

--- a/ZSWTappableLabel/ZSWTappableLabel.m
+++ b/ZSWTappableLabel/ZSWTappableLabel.m
@@ -227,21 +227,28 @@ NSString *const ZSWTappableLabelHighlightedForegroundAttributeName = @"ZSWTappab
 #pragma mark - UIGestureRecognizerDelegate
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch {
     __block BOOL shouldReceive = NO;
-    
-    [self performWithLayoutManager:^(NSUInteger (^characterIndexAtPoint)(CGPoint point),
-                                     CGRect (^screenFrameForCharacterRange)(NSRange characterRange)) {
-        NSUInteger characterIdx = characterIndexAtPoint([touch locationInView:self]);
-        
-        if (characterIdx != NSNotFound) {
-            NSNumber *attribute = [self.unmodifiedAttributedText attribute:ZSWTappableLabelTappableRegionAttributeName
-                                                                   atIndex:characterIdx
-                                                            effectiveRange:NULL];
-            shouldReceive = [attribute boolValue];
-        } else {
-            shouldReceive = NO;
-        }
-    } ignoringGestureRecognizers:YES];
-    
+
+    if ([self.tapDelegate respondsToSelector:@selector(tappableLabelShouldPassThroughUnhighlightedTouches:)])
+    {
+        shouldReceive = ![self.tapDelegate tappableLabelShouldPassThroughUnhighlightedTouches:self];
+    }
+    else
+    {
+        [self performWithLayoutManager:^(NSUInteger (^characterIndexAtPoint)(CGPoint point),
+                                         CGRect (^screenFrameForCharacterRange)(NSRange characterRange)) {
+            NSUInteger characterIdx = characterIndexAtPoint([touch locationInView:self]);
+
+            if (characterIdx != NSNotFound) {
+                NSNumber *attribute = [self.unmodifiedAttributedText attribute:ZSWTappableLabelTappableRegionAttributeName
+                                                                       atIndex:characterIdx
+                                                                effectiveRange:NULL];
+                shouldReceive = [attribute boolValue];
+            } else {
+                shouldReceive = NO;
+            }
+        } ignoringGestureRecognizers:YES];
+    }
+
     return shouldReceive;
 }
 


### PR DESCRIPTION
I added this method because when I tap on a region on a `ZSWTappableLabel` that isn't backed by a tappable region, I don't necessarily want it to pass touches through to the view below it.

In my case, I have a `ZSWTappableLabel` on a `UITableViewCell` in a `UITableView`, and it's triggering `tableView: didSelectRowAtIndexPath:` when I don't actually want that behavior in this case.

I'm not at all attached to the method name honestly, if you have any better ideas, I would be very happy to rename it.
