### PR TITLE
Fix non-left text alignment being set

### DIFF
--- a/ZSWTappableLabel/ZSWTappableLabel.m
+++ b/ZSWTappableLabel/ZSWTappableLabel.m
@@ -214,6 +214,22 @@ NSString *const ZSWTappableLabelHighlightedForegroundAttributeName = @"ZSWTappab
                                     }
                                 }];
         
+        if (self.textAlignment != NSTextAlignmentLeft) {
+            NSMutableParagraphStyle *style = [[NSMutableParagraphStyle alloc] init];
+            style.alignment = self.textAlignment;
+            
+            [attributedText enumerateAttribute:NSParagraphStyleAttributeName
+                                       inRange:NSMakeRange(0, attributedText.length)
+                                       options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
+                                    usingBlock:^(id value, NSRange range, BOOL *stop) {
+                                        if (!value) {
+                                            [mutableText addAttribute:NSParagraphStyleAttributeName
+                                                                value:style
+                                                                range:range];
+                                        }
+                                    }];
+        }
+        
         attributedText = mutableText;
     } else {
         self.tapGR.enabled = NO;


### PR DESCRIPTION
If the text alignment on the label is set, we need to make sure to inherit the alignment when configuring the attributed string we look at.

Otherwise, for example, centered text will be visually correct but the tap locations will be wrong.

Fixes #2
