### PR TITLE
Long-press recognition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3
+
+- Long press support: set a longPressDelegate (like tapDelegate) and be notified when the user long-presses.
+
 # 1.2 (2015-12-05)
 
 - Adds annotations for nullability and generics to ease Swift import.

--- a/Example/ZSWTappableLabel.xcodeproj/project.pbxproj
+++ b/Example/ZSWTappableLabel.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		110D6E4B1C25FEBA004E8551 /* SimpleSwiftViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110D6E4A1C25FEBA004E8551 /* SimpleSwiftViewController.swift */; };
 		110D6E4E1C25FEC6004E8551 /* SimpleObjectiveCViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 110D6E4D1C25FEC6004E8551 /* SimpleObjectiveCViewController.m */; };
 		110D6E501C25FF5C004E8551 /* RootExampleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110D6E4F1C25FF5C004E8551 /* RootExampleCell.swift */; };
+		11110E441C27543300E67ACD /* LongPressSwiftViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11110E431C27543300E67ACD /* LongPressSwiftViewController.swift */; };
 		116126D11C26094A003B4E43 /* MultipleSwiftViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116126D01C26094A003B4E43 /* MultipleSwiftViewController.swift */; };
 		116126D41C260961003B4E43 /* MultipleObjectiveCViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 116126D31C260961003B4E43 /* MultipleObjectiveCViewController.m */; };
 		116126DD1C260F67003B4E43 /* DataDetectorsSwiftViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116126DC1C260F67003B4E43 /* DataDetectorsSwiftViewController.swift */; };
@@ -53,6 +54,7 @@
 		110D6E4C1C25FEC6004E8551 /* SimpleObjectiveCViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SimpleObjectiveCViewController.h; sourceTree = "<group>"; };
 		110D6E4D1C25FEC6004E8551 /* SimpleObjectiveCViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SimpleObjectiveCViewController.m; sourceTree = "<group>"; };
 		110D6E4F1C25FF5C004E8551 /* RootExampleCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RootExampleCell.swift; sourceTree = "<group>"; };
+		11110E431C27543300E67ACD /* LongPressSwiftViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LongPressSwiftViewController.swift; sourceTree = "<group>"; };
 		116126D01C26094A003B4E43 /* MultipleSwiftViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipleSwiftViewController.swift; sourceTree = "<group>"; };
 		116126D21C260961003B4E43 /* MultipleObjectiveCViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MultipleObjectiveCViewController.h; sourceTree = "<group>"; };
 		116126D31C260961003B4E43 /* MultipleObjectiveCViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MultipleObjectiveCViewController.m; sourceTree = "<group>"; };
@@ -134,6 +136,14 @@
 				110D6E4D1C25FEC6004E8551 /* SimpleObjectiveCViewController.m */,
 			);
 			name = "Simple string";
+			sourceTree = "<group>";
+		};
+		11110E421C27541700E67ACD /* Long press */ = {
+			isa = PBXGroup;
+			children = (
+				11110E431C27543300E67ACD /* LongPressSwiftViewController.swift */,
+			);
+			name = "Long press";
 			sourceTree = "<group>";
 		};
 		116126CF1C26092B003B4E43 /* Multiple links */ = {
@@ -224,6 +234,7 @@
 				116126CF1C26092B003B4E43 /* Multiple links */,
 				116126DB1C260F55003B4E43 /* Data Detectors */,
 				116126E11C2612A3003B4E43 /* Interface Builder */,
+				11110E421C27541700E67ACD /* Long press */,
 			);
 			name = "Example for ZSWTappableLabel";
 			path = ZSWTappableLabel;
@@ -477,6 +488,7 @@
 				110D6E4E1C25FEC6004E8551 /* SimpleObjectiveCViewController.m in Sources */,
 				110D6E501C25FF5C004E8551 /* RootExampleCell.swift in Sources */,
 				116126DD1C260F67003B4E43 /* DataDetectorsSwiftViewController.swift in Sources */,
+				11110E441C27543300E67ACD /* LongPressSwiftViewController.swift in Sources */,
 				110D6E471C25FC33004E8551 /* AppDelegate.swift in Sources */,
 				110D6E451C25FC04004E8551 /* RootController.swift in Sources */,
 				116126D41C260961003B4E43 /* MultipleObjectiveCViewController.m in Sources */,

--- a/Example/ZSWTappableLabel.xcodeproj/project.pbxproj
+++ b/Example/ZSWTappableLabel.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		110D6E4E1C25FEC6004E8551 /* SimpleObjectiveCViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 110D6E4D1C25FEC6004E8551 /* SimpleObjectiveCViewController.m */; };
 		110D6E501C25FF5C004E8551 /* RootExampleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110D6E4F1C25FF5C004E8551 /* RootExampleCell.swift */; };
 		11110E441C27543300E67ACD /* LongPressSwiftViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11110E431C27543300E67ACD /* LongPressSwiftViewController.swift */; };
+		11110E471C2762A900E67ACD /* LongPressObjectiveCViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 11110E461C2762A900E67ACD /* LongPressObjectiveCViewController.m */; };
 		116126D11C26094A003B4E43 /* MultipleSwiftViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116126D01C26094A003B4E43 /* MultipleSwiftViewController.swift */; };
 		116126D41C260961003B4E43 /* MultipleObjectiveCViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 116126D31C260961003B4E43 /* MultipleObjectiveCViewController.m */; };
 		116126DD1C260F67003B4E43 /* DataDetectorsSwiftViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116126DC1C260F67003B4E43 /* DataDetectorsSwiftViewController.swift */; };
@@ -55,6 +56,8 @@
 		110D6E4D1C25FEC6004E8551 /* SimpleObjectiveCViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SimpleObjectiveCViewController.m; sourceTree = "<group>"; };
 		110D6E4F1C25FF5C004E8551 /* RootExampleCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RootExampleCell.swift; sourceTree = "<group>"; };
 		11110E431C27543300E67ACD /* LongPressSwiftViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LongPressSwiftViewController.swift; sourceTree = "<group>"; };
+		11110E451C2762A900E67ACD /* LongPressObjectiveCViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LongPressObjectiveCViewController.h; sourceTree = "<group>"; };
+		11110E461C2762A900E67ACD /* LongPressObjectiveCViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LongPressObjectiveCViewController.m; sourceTree = "<group>"; };
 		116126D01C26094A003B4E43 /* MultipleSwiftViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipleSwiftViewController.swift; sourceTree = "<group>"; };
 		116126D21C260961003B4E43 /* MultipleObjectiveCViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MultipleObjectiveCViewController.h; sourceTree = "<group>"; };
 		116126D31C260961003B4E43 /* MultipleObjectiveCViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MultipleObjectiveCViewController.m; sourceTree = "<group>"; };
@@ -142,6 +145,8 @@
 			isa = PBXGroup;
 			children = (
 				11110E431C27543300E67ACD /* LongPressSwiftViewController.swift */,
+				11110E451C2762A900E67ACD /* LongPressObjectiveCViewController.h */,
+				11110E461C2762A900E67ACD /* LongPressObjectiveCViewController.m */,
 			);
 			name = "Long press";
 			sourceTree = "<group>";
@@ -491,6 +496,7 @@
 				11110E441C27543300E67ACD /* LongPressSwiftViewController.swift in Sources */,
 				110D6E471C25FC33004E8551 /* AppDelegate.swift in Sources */,
 				110D6E451C25FC04004E8551 /* RootController.swift in Sources */,
+				11110E471C2762A900E67ACD /* LongPressObjectiveCViewController.m in Sources */,
 				116126D41C260961003B4E43 /* MultipleObjectiveCViewController.m in Sources */,
 				116126E41C2612BD003B4E43 /* InterfaceBuilderSwiftViewController.swift in Sources */,
 				116126E01C260F74003B4E43 /* DataDetectorsObjectiveCViewController.m in Sources */,

--- a/Example/ZSWTappableLabel/InterfaceBuilderSwiftViewController.swift
+++ b/Example/ZSWTappableLabel/InterfaceBuilderSwiftViewController.swift
@@ -13,6 +13,16 @@ import SafariServices
 class InterfaceBuilderSwiftViewController: UIViewController, ZSWTappableLabelTapDelegate {
     @IBOutlet weak var label: ZSWTappableLabel!
 
+    // for iOS 8
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
+        super.init(nibName: "InterfaceBuilderSwiftViewController", bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    // end for iOS 8
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/Example/ZSWTappableLabel/LongPressObjectiveCViewController.h
+++ b/Example/ZSWTappableLabel/LongPressObjectiveCViewController.h
@@ -1,0 +1,13 @@
+//
+//  LongPressObjectiveCViewController.h
+//  ZSWTappableLabel
+//
+//  Created by Zachary West on 12/20/15.
+//  Copyright © 2015 Zachary West. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface LongPressObjectiveCViewController : UIViewController
+
+@end

--- a/Example/ZSWTappableLabel/LongPressObjectiveCViewController.m
+++ b/Example/ZSWTappableLabel/LongPressObjectiveCViewController.m
@@ -1,0 +1,95 @@
+//
+//  LongPressObjectiveCViewController.m
+//  ZSWTappableLabel
+//
+//  Created by Zachary West on 12/20/15.
+//  Copyright © 2015 Zachary West. All rights reserved.
+//
+
+#import "LongPressObjectiveCViewController.h"
+
+@import Masonry;
+@import ZSWTappableLabel;
+@import ZSWTaggedString;
+@import SafariServices;
+
+static NSString *const URLAttributeName = @"URL";
+
+@interface LongPressObjectiveCViewController() <ZSWTappableLabelTapDelegate, ZSWTappableLabelLongPressDelegate>
+@property (nonatomic) ZSWTappableLabel *label;
+@end
+
+@implementation LongPressObjectiveCViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+    self.view.backgroundColor = [UIColor whiteColor];
+    
+    self.label = ^{
+        ZSWTappableLabel *label = [[ZSWTappableLabel alloc] init];
+        label.textAlignment = NSTextAlignmentJustified;
+        label.tapDelegate = self;
+        label.longPressDelegate = self;
+        label.longPressAccessibilityActionName = NSLocalizedString(@"Share", nil);
+        return label;
+    }();
+    
+    ZSWTaggedStringOptions *options = [ZSWTaggedStringOptions options];
+    [options setDynamicAttributes:^NSDictionary *(NSString *tagName,
+                                                  NSDictionary *tagAttributes,
+                                                  NSDictionary *existingStringAttributes) {
+        NSURL *URL;
+        if ([tagAttributes[@"type"] isEqualToString:@"privacy"]) {
+            URL = [NSURL URLWithString:@"http://google.com/search?q=privacy"];
+        } else if ([tagAttributes[@"type"] isEqualToString:@"tos"]) {
+            URL = [NSURL URLWithString:@"http://google.com/search?q=tos"];
+        }
+        
+        if (!URL) {
+            return nil;
+        }
+        
+        return @{
+                 ZSWTappableLabelTappableRegionAttributeName: @YES,
+                 ZSWTappableLabelHighlightedBackgroundAttributeName: [UIColor lightGrayColor],
+                 ZSWTappableLabelHighlightedForegroundAttributeName: [UIColor whiteColor],
+                 NSForegroundColorAttributeName: [UIColor blueColor],
+                 NSUnderlineStyleAttributeName: @(NSUnderlineStyleSingle),
+                 @"URL": URL
+                 };
+    } forTagName:@"link"];
+    
+    NSString *string = NSLocalizedString(@"Please, feel free to peruse and enjoy our wonderful and alluring <link type='privacy'>Privacy Policy</link> or if you'd really like to understand what you're allowed or not allowed to do, reading our <link type='tos'>Terms of Service</link> is sure to be enlightening", nil);
+    self.label.attributedText = [[ZSWTaggedString stringWithString:string] attributedStringWithOptions:options];
+    
+    [self.view addSubview:self.label];
+    [self.label mas_makeConstraints:^(MASConstraintMaker *make) {
+        make.edges.equalTo(self.view);
+    }];
+}
+
+#pragma mark - ZSWTappableLabelTapDelegate
+
+- (void)tappableLabel:(ZSWTappableLabel *)tappableLabel tappedAtIndex:(NSInteger)idx withAttributes:(NSDictionary<NSString *,id> *)attributes {
+    NSURL *URL = attributes[URLAttributeName];
+    if ([URL isKindOfClass:[NSURL class]]) {
+        if ([SFSafariViewController class] != nil) {
+            [self showViewController:[[SFSafariViewController alloc] initWithURL:URL] sender:self];
+        } else {
+            [[UIApplication sharedApplication] openURL:URL];
+        }
+    }
+}
+
+#pragma mark - ZSWTappableLabelLongPressDelegate
+
+- (void)tappableLabel:(ZSWTappableLabel *)tappableLabel longPressedAtIndex:(NSInteger)idx withAttributes:(NSDictionary<NSString *,id> *)attributes {
+    NSURL *URL = attributes[URLAttributeName];
+    if ([URL isKindOfClass:[NSURL class]]) {
+        UIActivityViewController *activityController = [[UIActivityViewController alloc] initWithActivityItems:@[ URL ] applicationActivities:nil];
+        [self presentViewController:activityController animated:YES completion:nil];
+    }
+}
+
+@end

--- a/Example/ZSWTappableLabel/LongPressSwiftViewController.swift
+++ b/Example/ZSWTappableLabel/LongPressSwiftViewController.swift
@@ -1,0 +1,95 @@
+//
+//  LongPressSwiftViewController.swift
+//  ZSWTappableLabel
+//
+//  Created by Zachary West on 12/20/15.
+//  Copyright © 2015 Zachary West. All rights reserved.
+//
+
+import ZSWTappableLabel
+import ZSWTaggedString
+import SafariServices
+
+class LongPressSwiftViewController: UIViewController, ZSWTappableLabelTapDelegate, ZSWTappableLabelLongPressDelegate {
+    let label: ZSWTappableLabel = {
+        let label = ZSWTappableLabel()
+        label.textAlignment = .Justified
+        return label
+    }()
+    
+    static let URLAttributeName = "URL"
+    
+    enum LinkType: String {
+        case Privacy = "privacy"
+        case TermsOfService = "tos"
+        
+        var URL: NSURL {
+            switch self {
+            case .Privacy:
+                return NSURL(string: "http://google.com/search?q=privacy")!
+            case .TermsOfService:
+                return NSURL(string: "http://google.com/search?q=tos")!
+            }
+        }
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.backgroundColor = UIColor.whiteColor()
+        
+        label.tapDelegate = self
+        label.longPressDelegate = self
+        label.longPressAccessibilityActionName = NSLocalizedString("Share", comment: "")
+        
+        let options = ZSWTaggedStringOptions()
+        options["link"] = .Dynamic({ tagName, tagAttributes, stringAttributes in
+            guard let typeString = tagAttributes["type"] as? String,
+                let type = LinkType(rawValue: typeString) else {
+                    return [String: AnyObject]()
+            }
+            
+            return [
+                ZSWTappableLabelTappableRegionAttributeName: true,
+                ZSWTappableLabelHighlightedBackgroundAttributeName: UIColor.lightGrayColor(),
+                ZSWTappableLabelHighlightedForegroundAttributeName: UIColor.whiteColor(),
+                NSForegroundColorAttributeName: UIColor.blueColor(),
+                NSUnderlineStyleAttributeName: NSUnderlineStyle.StyleSingle.rawValue,
+                MultipleSwiftViewController.URLAttributeName: type.URL
+            ]
+        })
+        
+        let string = NSLocalizedString("Please, feel free to peruse and enjoy our wonderful and alluring <link type='privacy'>Privacy Policy</link> or if you'd really like to understand what you're allowed or not allowed to do, reading our <link type='tos'>Terms of Service</link> is sure to be enlightening", comment: "")
+        label.attributedText = try? ZSWTaggedString(string: string).attributedStringWithOptions(options)
+        
+        view.addSubview(label)
+        label.snp_makeConstraints { make in
+            make.edges.equalTo(view)
+        }
+    }
+    
+    // MARK: - ZSWTappableLabelTapDelegate
+    
+    func tappableLabel(tappableLabel: ZSWTappableLabel, tappedAtIndex idx: Int, withAttributes attributes: [String : AnyObject]) {
+        guard let URL = attributes[SimpleSwiftViewController.URLAttributeName] as? NSURL else {
+            return
+        }
+        
+        if #available(iOS 9, *) {
+            showViewController(SFSafariViewController(URL: URL), sender: self)
+        } else {
+            UIApplication.sharedApplication().openURL(URL)
+        }
+    }
+    
+    // MARK: - ZSWTappableLabelLongPressDelegate
+    
+    func tappableLabel(tappableLabel: ZSWTappableLabel, longPressedAtIndex idx: Int, withAttributes attributes: [String : AnyObject]) {
+        guard let URL = attributes[SimpleSwiftViewController.URLAttributeName] as? NSURL else {
+            return
+        }
+        
+        let activityController = UIActivityViewController(activityItems: [URL], applicationActivities: nil)
+        presentViewController(activityController, animated: true, completion: nil)
+    }
+}

--- a/Example/ZSWTappableLabel/RootController.swift
+++ b/Example/ZSWTappableLabel/RootController.swift
@@ -49,7 +49,7 @@ class RootController: UIViewController, UITableViewDelegate, UITableViewDataSour
         examples.append(ExampleRow(name: "Long press", body: "Long press triggers an Activity View Controller, tapping opens the link.", constructorSwift: { () -> UIViewController in
             return LongPressSwiftViewController()
         }, constructorObjectiveC: { () -> UIViewController in
-            return LongPressSwiftViewController()
+            return LongPressObjectiveCViewController()
         }))
         
         self.examples = examples

--- a/Example/ZSWTappableLabel/RootController.swift
+++ b/Example/ZSWTappableLabel/RootController.swift
@@ -46,6 +46,12 @@ class RootController: UIViewController, UITableViewDelegate, UITableViewDataSour
             return InterfaceBuilderObjectiveCViewController()
         }))
         
+        examples.append(ExampleRow(name: "Long press", body: "Long press triggers an Activity View Controller, tapping opens the link.", constructorSwift: { () -> UIViewController in
+            return LongPressSwiftViewController()
+        }, constructorObjectiveC: { () -> UIViewController in
+            return LongPressSwiftViewController()
+        }))
+        
         self.examples = examples
         
         super.init(nibName: nil, bundle: nil)

--- a/Example/ZSWTappableLabel/ZSWTappableLabel_Example-Bridging-Header.h
+++ b/Example/ZSWTappableLabel/ZSWTappableLabel_Example-Bridging-Header.h
@@ -6,3 +6,4 @@
 #import "MultipleObjectiveCViewController.h"
 #import "DataDetectorsObjectiveCViewController.h"
 #import "InterfaceBuilderObjectiveCViewController.h"
+#import "LongPressObjectiveCViewController.h"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/cocoapods/l/ZSWTappableLabel.svg?style=flat)](http://cocoapods.org/pods/ZSWTappableLabel)
 [![Platform](https://img.shields.io/cocoapods/p/ZSWTappableLabel.svg?style=flat)](http://cocoapods.org/pods/ZSWTappableLabel)
 
-ZSWTappableLabel is a `UILabel` subclass powered by NSAttributedStrings which allows you to tap on certain regions, with optional highlight behavior. It does not draw text itself and executes a minimal amount of code unless the user is interacting with a tappable region.
+ZSWTappableLabel is a `UILabel` subclass powered by NSAttributedStrings which allows you to tap or long-press on certain regions, with optional highlight behavior. It does not draw text itself and executes a minimal amount of code unless the user is interacting with a tappable region.
 
 ## A basic, tappable link
 
@@ -291,7 +291,7 @@ For example, if you place a UITapGestureRecognizer on the label, it will only fi
 ZSWTappableLabel is available through [CocoaPods](http://cocoapods.org). To install it, simply add the following line to your Podfile:
 
 ```ruby
-pod "ZSWTappableLabel", "~> 1.2"
+pod "ZSWTappableLabel", "~> 1.3"
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -65,6 +65,35 @@ func tappableLabel(tappableLabel: ZSWTappableLabel, tappedAtIndex idx: Int, with
 }
 ```
 
+## Long-presses
+
+You may optionally support long-presses by setting a `longPressDelegate` on the label. This behaves very similarly to the `tapDelegate`:
+
+```swift
+func tappableLabel(tappableLabel: ZSWTappableLabel, longPressedAtIndex idx: Int, withAttributes attributes: [String : AnyObject]) {
+  guard let URL = attributes["URL"] as? NSURL else {
+    return
+  }
+    
+  let activityController = UIActivityViewController(activityItems: [URL], applicationActivities: nil)
+  presentViewController(activityController, animated: true, completion: nil)
+}
+```
+
+```objectivec
+- (void)tappableLabel:(ZSWTappableLabel *)tappableLabel 
+   longPressedAtIndex:(NSInteger)idx 
+       withAttributes:(NSDictionary<NSString *,id> *)attributes {
+  NSURL *URL = attributes[URLAttributeName];
+  if ([URL isKindOfClass:[NSURL class]]) {
+    UIActivityViewController *activityController = [[UIActivityViewController alloc] initWithActivityItems:@[ URL ] applicationActivities:nil];
+    [self presentViewController:activityController animated:YES completion:nil];
+  }
+}
+```
+
+You can configure the `longPressDuration` for how long until a long-press is recognized, and the `longPressAccessibilityActionName` which is read aloud to users for [VoiceOver](#voiceover).
+
 ## Data detectors
 
 Let's use `NSDataDetector` to find the substrings in a given string that we might want to turn into links:
@@ -244,6 +273,8 @@ ZSWTappableLabel is an accessibility container, which exposes the substrings in 
 1. `Privacy Policy` (link)
 1. ` or ` (static text)
 1. `Terms of Service` (link)
+
+When you set a `longPressDelegate`, an additional action on links is added to perform the long-press gesture. You should configure the `longPressAccessibilityActionName` to adjust what is read to users.
 
 ## Interaction with gesture recognizers
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ func tappableLabel(tappableLabel: ZSWTappableLabel, longPressedAtIndex idx: Int,
 }
 ```
 
-You can configure the `longPressDuration` for how long until a long-press is recognized, and the `longPressAccessibilityActionName` which is read aloud to users for [VoiceOver](#voiceover).
+You can configure the `longPressDuration` for how long until a long-press is recognized. This defaults to 0.5 seconds.
 
 ## Data detectors
 

--- a/ZSWTappableLabel.podspec
+++ b/ZSWTappableLabel.podspec
@@ -1,9 +1,9 @@
 Pod::Spec.new do |s|
   s.name             = "ZSWTappableLabel"
-  s.version          = "1.2"
+  s.version          = "1.3"
   s.summary          = "UILabel subclass in which substrings links can be tapped"
   s.description      = <<-DESC
-                        NSAttributedStrings presented in ZSWTappableLabel can be tapped
+                        NSAttributedStrings presented in ZSWTappableLabel can be tapped or long-pressed
                         in subranges you specify using attributes.
                         Read more: https://github.com/zacwest/ZSWTappableLabel
                        DESC

--- a/ZSWTappableLabel/ZSWTappableLabel.h
+++ b/ZSWTappableLabel/ZSWTappableLabel.h
@@ -62,11 +62,66 @@ extern NSString *const ZSWTappableLabelTappableRegionAttributeName;
        withAttributes:(NSDictionary<NSString *, id> *)attributes;
 @end
 
+@protocol ZSWTappableLabelLongPressDelegate
+/*!
+ * @brief A long press was completed
+ *
+ * @param tappableLabel
+ * @param idx The string index closest to the touch
+ * @param attributes The attributes from the attributed string at the given index
+ *
+ * This method is only invoked if \ref ZSWTappableLabelTappableRegionAttributeName
+ * is specified in the attributes under the touch.
+ *
+ * If the user presses and holds at one spot for at least
+ * \ref longPressDuration seconds, this delegate method will be invoked.
+ *
+ * It may also be invoked by users with accessibility enabled. You should set
+ * \ref longPressAccessibilityActionName to give your users
+ * a better description of what this does.
+ */
+- (void)tappableLabel:(ZSWTappableLabel *)tappableLabel
+   longPressedAtIndex:(NSInteger)idx
+       withAttributes:(NSDictionary<NSString *, id> *)attributes;
+@end
+
 #pragma mark -
 
 @interface ZSWTappableLabel : UILabel
 
+/*!
+ * @brief Delegate which handles taps
+ */
 @property (nullable, nonatomic, weak) IBOutlet id<ZSWTappableLabelTapDelegate> tapDelegate;
+
+/*!
+ * @brief Delegate which handles long-presses
+ */
+@property (nullable, nonatomic, weak) IBOutlet id<ZSWTappableLabelLongPressDelegate> longPressDelegate;
+
+/*!
+ * @brief Long press duration
+ *
+ * How long, in seconds, the user must long press without lifting before
+ * the touch should be recognized as a long press.
+ *
+ * If you do not set a \ref longPressDelegate, a long press does not occur.
+ *
+ * This defaults to 1.0 seconds.
+ */
+@property (nonatomic) NSTimeInterval longPressDuration;
+
+/*!
+ * @brief Accessibility label for long press
+ *
+ * Your users will be read this localized string when they choose to
+ * dig into the custom actions a link has.
+ *
+ * If you do not set a \ref longPressDelegate, this action is not included.
+ *
+ * This defaults to 'Open Menu'.
+ */
+@property (nonatomic, copy) NSString *longPressAccessibilityActionName;
 
 @end
 

--- a/ZSWTappableLabel/ZSWTappableLabel.h
+++ b/ZSWTappableLabel/ZSWTappableLabel.h
@@ -107,7 +107,7 @@ extern NSString *const ZSWTappableLabelTappableRegionAttributeName;
  *
  * If you do not set a \ref longPressDelegate, a long press does not occur.
  *
- * This defaults to 1.0 seconds.
+ * This defaults to 0.5 seconds.
  */
 @property (nonatomic) NSTimeInterval longPressDuration;
 

--- a/ZSWTappableLabel/ZSWTappableLabel.h
+++ b/ZSWTappableLabel/ZSWTappableLabel.h
@@ -121,7 +121,7 @@ extern NSString *const ZSWTappableLabelTappableRegionAttributeName;
  *
  * This defaults to 'Open Menu'.
  */
-@property (nonatomic, copy) NSString *longPressAccessibilityActionName;
+@property (null_resettable, nonatomic, copy) NSString *longPressAccessibilityActionName;
 
 @end
 

--- a/ZSWTappableLabel/ZSWTappableLabel.m
+++ b/ZSWTappableLabel/ZSWTappableLabel.m
@@ -75,7 +75,7 @@ typedef NS_ENUM(NSInteger, ZSWTappableLabelNotifyType) {
     self.numberOfLines = 0;
     self.lineBreakMode = NSLineBreakByWordWrapping;
     
-    self.longPressDuration = 1;
+    self.longPressDuration = 0.5;
     self.longPressAccessibilityActionName = nil; // reset value
     
     self.longPressGR = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(longPress:)];

--- a/ZSWTappableLabel/ZSWTappableLabel.m
+++ b/ZSWTappableLabel/ZSWTappableLabel.m
@@ -11,9 +11,27 @@
 
 #import "ZSWTappableLabel.h"
 
+@interface ZSWTappableLabelAccessibilityActionLongPress: UIAccessibilityCustomAction
+@property (nonatomic) NSUInteger characterIndex;
+@end
+
+@implementation ZSWTappableLabelAccessibilityActionLongPress
+@end
+
+#pragma mark -
+
 NSString *const ZSWTappableLabelHighlightedBackgroundAttributeName = @"ZSWTappableLabelHighlightedBackgroundAttributeName";
 NSString *const ZSWTappableLabelTappableRegionAttributeName = @"ZSWTappableLabelTappableRegionAttributeName";
 NSString *const ZSWTappableLabelHighlightedForegroundAttributeName = @"ZSWTappableLabelHighlightedForegroundAttributeName";
+
+NSString *const ZSWTappableLabelCharacterIndexUserInfoKey = @"CharacterIndex";
+
+typedef NS_ENUM(NSInteger, ZSWTappableLabelNotifyType) {
+    ZSWTappableLabelNotifyTypeTap = 1,
+    ZSWTappableLabelNotifyTypeLongPress,
+};
+
+#pragma mark -
 
 @interface ZSWTappableLabel() <UIGestureRecognizerDelegate>
 @property (nonatomic) NSArray *accessibleElements;
@@ -26,6 +44,8 @@ NSString *const ZSWTappableLabelHighlightedForegroundAttributeName = @"ZSWTappab
 
 @property (nonatomic) UILongPressGestureRecognizer *longPressGR;
 @property (nonatomic) UITapGestureRecognizer *tapGR;
+
+@property (nonatomic) NSTimer *longPressTriggerTimer;
 @end
 
 @implementation ZSWTappableLabel
@@ -55,6 +75,9 @@ NSString *const ZSWTappableLabelHighlightedForegroundAttributeName = @"ZSWTappab
     self.numberOfLines = 0;
     self.lineBreakMode = NSLineBreakByWordWrapping;
     
+    self.longPressDuration = 1;
+    self.longPressAccessibilityActionName = nil; // reset value
+    
     self.longPressGR = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(longPress:)];
     self.longPressGR.delegate = self;
     self.longPressGR.minimumPressDuration = 0.15; // trying to match timing of UICollectionView's highlight LPGR
@@ -63,6 +86,21 @@ NSString *const ZSWTappableLabelHighlightedForegroundAttributeName = @"ZSWTappab
     self.tapGR = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tap:)];
     self.tapGR.delegate = self;
     [self addGestureRecognizer:self.tapGR];
+}
+
+- (void)setLongPressDelegate:(id<ZSWTappableLabelLongPressDelegate>)longPressDelegate {
+    _longPressDelegate = longPressDelegate;
+    _accessibleElements = nil;
+}
+
+- (void)setLongPressAccessibilityActionName:(NSString *)longPressAccessibilityActionName {
+    _longPressAccessibilityActionName = longPressAccessibilityActionName ?: NSLocalizedString(@"Open Menu", nil);
+    _accessibleElements = nil;
+}
+
+- (void)setUnmodifiedAttributedText:(NSAttributedString *)unmodifiedAttributedText {
+    _unmodifiedAttributedText = unmodifiedAttributedText;
+    _accessibleElements = nil;
 }
 
 - (void)createTextStorage {
@@ -173,11 +211,6 @@ NSString *const ZSWTappableLabelHighlightedForegroundAttributeName = @"ZSWTappab
 
 - (NSString *)text {
     return self.unmodifiedAttributedText.string;
-}
-
-- (void)setUnmodifiedAttributedText:(NSAttributedString *)unmodifiedAttributedText {
-    _unmodifiedAttributedText = unmodifiedAttributedText;
-    _accessibleElements = nil;
 }
 
 - (void)setAttributedText:(NSAttributedString *)attributedText {
@@ -306,6 +339,7 @@ NSString *const ZSWTappableLabelHighlightedForegroundAttributeName = @"ZSWTappab
                                      range:foregroundEffectiveRange];
         }
         
+        [self beginLongPressAtIndex:characterIndex];
         [super setAttributedText:attributedString];
     } else {
         [self removeHighlight];
@@ -314,22 +348,65 @@ NSString *const ZSWTappableLabelHighlightedForegroundAttributeName = @"ZSWTappab
 
 - (void)removeHighlight {
     [super setAttributedText:self.unmodifiedAttributedText];
+    [self cancelLongPressTimer];
 }
 
-- (void)notifyForCharacterIndex:(NSUInteger)characterIndex {
+- (void)notifyForCharacterIndex:(NSUInteger)characterIndex type:(ZSWTappableLabelNotifyType)notifyType {
     if (characterIndex == NSNotFound) {
         return;
     }
     
     NSDictionary *attributes = [self.unmodifiedAttributedText attributesAtIndex:characterIndex effectiveRange:NULL] ?: @{};
     
-#if DEBUG
-    NSLog(@"Tapped at index %@ with attributes %@", @(characterIndex), attributes);
-#endif
+    switch (notifyType) {
+        case ZSWTappableLabelNotifyTypeTap:
+            [self.tapDelegate tappableLabel:self
+                              tappedAtIndex:characterIndex
+                             withAttributes:attributes];
+            break;
+            
+        case ZSWTappableLabelNotifyTypeLongPress:
+            [self.longPressDelegate tappableLabel:self
+                               longPressedAtIndex:characterIndex
+                                   withAttributes:attributes];
+            break;
+    }
+}
+
+- (void)beginLongPressAtIndex:(NSUInteger)characterIndex {
+    if (!self.longPressDelegate) {
+        return;
+    }
     
-    [self.tapDelegate tappableLabel:self
-                      tappedAtIndex:characterIndex
-                     withAttributes:attributes];
+    NSDictionary *userInfo = @{
+        ZSWTappableLabelCharacterIndexUserInfoKey: @(characterIndex)
+    };
+    
+    [self.longPressTriggerTimer invalidate];
+    self.longPressTriggerTimer = [NSTimer scheduledTimerWithTimeInterval:self.longPressDuration target:self selector:@selector(longPressForTimer:) userInfo:userInfo repeats:NO];
+}
+
+- (void)cancelLongPressTimer {
+    [self.longPressTriggerTimer invalidate];
+    self.longPressTriggerTimer = nil;
+}
+
+- (void)longPressForTimer:(NSTimer *)timer {
+    NSDictionary *userInfo = timer.userInfo;
+    
+    [self cancelLongPressTimer];
+    
+    // Cancel the long press gesture so it doesn't fire after this
+    self.longPressGR.enabled = NO;
+    self.longPressGR.enabled = YES;
+    
+    NSUInteger characterIndex = [userInfo[ZSWTappableLabelCharacterIndexUserInfoKey] unsignedIntegerValue];
+    [self notifyForCharacterIndex:characterIndex type:ZSWTappableLabelNotifyTypeLongPress];
+}
+
+- (BOOL)longPressForAccessibilityAction:(ZSWTappableLabelAccessibilityActionLongPress *)action {
+    [self notifyForCharacterIndex:action.characterIndex type:ZSWTappableLabelNotifyTypeLongPress];
+    return YES;
 }
 
 - (void)tap:(UITapGestureRecognizer *)tapGR {
@@ -342,7 +419,7 @@ NSString *const ZSWTappableLabelHighlightedForegroundAttributeName = @"ZSWTappab
         }
         
         [self applyHighlightAtIndex:characterIndex];
-        [self notifyForCharacterIndex:characterIndex];
+        [self notifyForCharacterIndex:characterIndex type:ZSWTappableLabelNotifyTypeTap];
         [self removeHighlight];
     } ignoringGestureRecognizers:NO];
 }
@@ -368,7 +445,7 @@ NSString *const ZSWTappableLabelHighlightedForegroundAttributeName = @"ZSWTappab
                 
             case UIGestureRecognizerStateEnded: {
                 NSUInteger characterIndex = characterIndexAtPoint([longPressGR locationInView:self]);
-                [self notifyForCharacterIndex:characterIndex];
+                [self notifyForCharacterIndex:characterIndex type:ZSWTappableLabelNotifyTypeTap];
                 [self removeHighlight];
                 break;
             }
@@ -413,6 +490,13 @@ NSString *const ZSWTappableLabelHighlightedForegroundAttributeName = @"ZSWTappab
                 element.accessibilityTraits = UIAccessibilityTraitLink | UIAccessibilityTraitStaticText;
             } else {
                 element.accessibilityTraits = UIAccessibilityTraitStaticText;
+            }
+            
+            if (self.longPressDelegate) {
+                ZSWTappableLabelAccessibilityActionLongPress *action = [[ZSWTappableLabelAccessibilityActionLongPress alloc] initWithName:self.longPressAccessibilityActionName target:self selector:@selector(longPressForAccessibilityAction:)];
+                action.characterIndex = range.location;
+                
+                element.accessibilityCustomActions = @[ action ];
             }
             
             [accessibleElements addObject:element];


### PR DESCRIPTION
Fixes #4 by adding a new `longPressDelegate`:

``` objectivec
@protocol ZSWTappableLabelLongPressDelegate
/*!
 * @brief A long press was completed
 *
 * @param tappableLabel
 * @param idx The string index closest to the touch
 * @param attributes The attributes from the attributed string at the given index
 *
 * This method is only invoked if \ref ZSWTappableLabelTappableRegionAttributeName
 * is specified in the attributes under the touch.
 *
 * If the user presses and holds at one spot for at least
 * \ref longPressDuration seconds, this delegate method will be invoked.
 *
 * It may also be invoked by users with accessibility enabled. You should set
 * \ref longPressAccessibilityActionName to give your users
 * a better description of what this does.
 */
- (void)tappableLabel:(ZSWTappableLabel *)tappableLabel
   longPressedAtIndex:(NSInteger)idx
       withAttributes:(NSDictionary<NSString *, id> *)attributes;
@end
```

When the delegate is set, after `longPressDuration` seconds of holding on the same character, the above method is invoked on it.
