### PR TITLE
fixes non-tappable last line attributes when rendering multiline text

### DIFF
--- a/ZSWTappableLabel/ZSWTappableLabel.m
+++ b/ZSWTappableLabel/ZSWTappableLabel.m
@@ -108,8 +108,12 @@ typedef NS_ENUM(NSInteger, ZSWTappableLabelNotifyType) {
         return;
     }
     
-    NSTextStorage *textStorage = [[NSTextStorage alloc] initWithAttributedString:self.unmodifiedAttributedText];
-    NSTextContainer *textContainer = [[NSTextContainer alloc] initWithSize:self.bounds.size];
+    NSTextStorage *textStorage = [[NSTextStorage alloc] initWithAttributedString:self.unmodifiedAttributedText];    // on iOS 10, UILabel sometimes renders multiline labels
+    // while at the same bounds size, NSLayoutManager will render 1 line
+    // this causes a mismatch in character locations between label and manager
+    // so we use a infinite height here to allow the manager to render similarly
+    CGSize adjustedSize =  CGSizeMake(self.bounds.size.width, CGFLOAT_MAX);
+    NSTextContainer *textContainer = [[NSTextContainer alloc] initWithSize:adjustedSize];
     NSLayoutManager *layoutManager = [[NSLayoutManager alloc] init];
 
     textContainer.lineBreakMode = self.lineBreakMode;


### PR DESCRIPTION
When rendering a multiline text label with numberOfLines == 0, the attributes in the second or greater line, may not be tappable on iOS 10. The issue is the layout manager seems to be rendering a single line of text (judged by its size), despite being given numberOfLines ==0. The fix is to give the layout manager an infinite height, which will always force it to draw multi lines if necessary 