### PR TITLE
Improve generation of accessibility elements

### DIFF
--- a/ZSWTappableLabel/ZSWTappableLabel.m
+++ b/ZSWTappableLabel/ZSWTappableLabel.m
@@ -510,7 +510,7 @@ typedef NS_ENUM(NSInteger, ZSWTappableLabelNotifyType) {
         
         [unmodifiedAttributedString enumerateAttribute:ZSWTappableLabelTappableRegionAttributeName
                                                inRange:NSMakeRange(0, unmodifiedAttributedString.length)
-                                               options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
+                                               options:0
                                             usingBlock:enumerationBlock];
     }];
 


### PR DESCRIPTION
When enumerating over the attributed string to generate accessibility elements, require "longest effective range" so that runs of characters outside of links are unbroken.

When the LongestEffectiveRangeNotRequired option is set, the enumeration separates runs when any attribute changes. For example, if part of the string is italicized, it'll be a separate element.

By not setting the option, separate accessibility elements are only generated for links.