### PR TITLE
Fix orphan (single-word last line) tappability by using line break strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.3 (2021-04-02)
+
+- Fixes tappability of regions relocated to a new line to avoid single-word last lines by UILabel. This requires compiling using Xcode 12, but works backwards-compatibly.
+- Fixes accessibility elements sometimes exposing more than 1 element per tappable span.
+
 # 3.2 (2020-04-17)
 
 - Fixes handling accessibility element activation that spans multiple lines.

--- a/ZSWTappableLabel/ZSWTappableLabel.m
+++ b/ZSWTappableLabel/ZSWTappableLabel.m
@@ -137,10 +137,18 @@ typedef NS_ENUM(NSInteger, ZSWTappableLabelNotifyType) {
                                                         range:range];
                                 }
                             }];
-    
+
+#ifdef __IPHONE_14_0
+    // lineBreakStrategy was exposed publicly in Xcode 12, but works backwords-compatibly
+    if (self.textAlignment != NSTextAlignmentLeft || self.lineBreakStrategy != NSLineBreakStrategyNone) {
+#else
     if (self.textAlignment != NSTextAlignmentLeft) {
+#endif
         NSMutableParagraphStyle *style = [[NSMutableParagraphStyle alloc] init];
         style.alignment = self.textAlignment;
+#ifdef __IPHONE_14_0
+        style.lineBreakStrategy = self.lineBreakStrategy;
+#endif
         
         [attributedText enumerateAttribute:NSParagraphStyleAttributeName
                                    inRange:NSMakeRange(0, attributedText.length)


### PR DESCRIPTION
Fixes #42.

Fixes tappability of regions relocated to a new line to avoid single-word last lines by UILabel. Xcode 12 (and the iOS 14 SDK) expose `.lineBreakStrategy` which is a new value on `UILabel` and `NSParagraphStyle` to control the orphan avoidance and line break positioning in strings.

This new method/enum is backwards compatible as it seems to be formerly-private API made public, so it works on all versions of iOS the label supports as long as you compile using Xcode 12.